### PR TITLE
Fix Style CI configuration

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/src/Drivers/ApiDriver.php
+++ b/src/Drivers/ApiDriver.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\Gammu\Drivers;
 
-use Illuminate\Contracts\Config\Repository;
 use GuzzleHttp\Client;
+use Illuminate\Contracts\Config\Repository;
 use NotificationChannels\Gammu\Exceptions\CouldNotSendNotification;
 
 class ApiDriver extends DriverAbstract

--- a/src/Drivers/DbDriver.php
+++ b/src/Drivers/DbDriver.php
@@ -2,12 +2,12 @@
 
 namespace NotificationChannels\Gammu\Drivers;
 
+use Exception;
 use Illuminate\Contracts\Config\Repository;
+use NotificationChannels\Gammu\Models\Phone;
 use NotificationChannels\Gammu\Models\Outbox;
 use NotificationChannels\Gammu\Models\OutboxMultipart;
-use NotificationChannels\Gammu\Models\Phone;
 use NotificationChannels\Gammu\Exceptions\CouldNotSendNotification;
-use Exception;
 
 class DbDriver extends DriverAbstract
 {
@@ -214,7 +214,7 @@ class DbDriver extends DriverAbstract
         $ref = mt_rand(0, 255);
         $i = 1;
         $firstUDH = $this->generateUDH($messagesCount, $i, $ref);
-        ++$i;
+        $i++;
 
         $this->data['TextDecoded'] = $firstChunk;
         $this->data['UDH'] = $firstUDH;
@@ -226,7 +226,7 @@ class DbDriver extends DriverAbstract
                 'TextDecoded' => $chunk,
                 'SequencePosition' => $i,
             ]);
-            ++$i;
+            $i++;
         }
 
         $this->isLongSms = true;

--- a/src/Drivers/RedisDriver.php
+++ b/src/Drivers/RedisDriver.php
@@ -2,9 +2,8 @@
 
 namespace NotificationChannels\Gammu\Drivers;
 
-use Illuminate\Contracts\Config\Repository;
-use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Redis;
+use Illuminate\Contracts\Config\Repository;
 use NotificationChannels\Gammu\Exceptions\CouldNotSendNotification;
 
 class RedisDriver extends DriverAbstract
@@ -34,17 +33,18 @@ class RedisDriver extends DriverAbstract
         $this->setDestination($phoneNumber);
         $this->setContent($content);
         $this->setChannel($channel);
-        
+
         Redis::publish($this->channel, json_encode([
             'to' => $this->destination,
             'message' => $this->content,
-            'callback' => $this->callback
+            'callback' => $this->callback,
         ]));
     }
 
     public function setChannel($channel)
     {
-        $this->channel = !$channel ? 'gammu-channel' : $channel;
+        $this->channel = ! $channel ? 'gammu-channel' : $channel;
+
         return $this;
     }
 

--- a/tests/Drivers/ApiDriverTest.php
+++ b/tests/Drivers/ApiDriverTest.php
@@ -2,11 +2,11 @@
 
 namespace NotificationChannels\Gammu\Test\Drivers;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
 use NotificationChannels\Gammu\Test\TestBase;
 use NotificationChannels\Gammu\Drivers\ApiDriver;
 use NotificationChannels\Gammu\Exceptions\CouldNotSendNotification;
-use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
 
 class ApiDriverTest extends TestBase implements DriverTestInterface
 {

--- a/tests/Drivers/DbDriverTest.php
+++ b/tests/Drivers/DbDriverTest.php
@@ -2,11 +2,11 @@
 
 namespace NotificationChannels\Gammu\Test\Drivers;
 
+use NotificationChannels\Gammu\Models\Phone;
+use NotificationChannels\Gammu\Models\Outbox;
 use NotificationChannels\Gammu\Test\TestBase;
 use NotificationChannels\Gammu\Drivers\DbDriver;
 use NotificationChannels\Gammu\Exceptions\CouldNotSendNotification;
-use NotificationChannels\Gammu\Models\Phone;
-use NotificationChannels\Gammu\Models\Outbox;
 
 class DbDriverTest extends TestBase
 {

--- a/tests/GammuChannelTest.php
+++ b/tests/GammuChannelTest.php
@@ -4,12 +4,12 @@ namespace NotificationChannels\Gammu\Test;
 
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
-use NotificationChannels\Gammu\Drivers\RedisDriver;
 use NotificationChannels\Gammu\GammuChannel;
 use NotificationChannels\Gammu\GammuMessage;
+use NotificationChannels\Gammu\Models\Phone;
 use NotificationChannels\Gammu\Drivers\DbDriver;
 use NotificationChannels\Gammu\Drivers\ApiDriver;
-use NotificationChannels\Gammu\Models\Phone;
+use NotificationChannels\Gammu\Drivers\RedisDriver;
 
 class GammuChannelTest extends TestBase
 {

--- a/tests/MigrationTest.php
+++ b/tests/MigrationTest.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\Gammu\Test;
 
-use FilesystemIterator;
 use DB;
+use FilesystemIterator;
 
 class MigrationTest extends TestBase
 {

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -2,10 +2,10 @@
 
 namespace NotificationChannels\Gammu\Test;
 
-use NotificationChannels\Gammu\GammuServiceProvider;
-use Orchestra\Testbench\TestCase;
 use Mockery;
 use Faker\Factory;
+use Orchestra\Testbench\TestCase;
+use NotificationChannels\Gammu\GammuServiceProvider;
 
 abstract class TestBase extends TestCase
 {


### PR DESCRIPTION
This removes the deprecated Style CI `linting` flag, and applies the required formatting changes.